### PR TITLE
Add closing brackets to common.js

### DIFF
--- a/data/common.js
+++ b/data/common.js
@@ -531,6 +531,7 @@
                 if (!errorMessage) {
                   processStatus(ID, e.id, value);
                 }
+              }
               else if (e.type === 'checkbox') processStatus(ID, e.id, e.checked ? 1 : 0);
               else if (et === 'button' || et === 'file') processStatus(ID, e.id, 1);
               else if (et === 'radio') { if (e.checked) processStatus(ID, e.name, value); } 


### PR DESCRIPTION
Browser console shows syntax errors when rendering. One immediate fix is to address missing brackets.
![Captura de tela 2025-05-26 174931](https://github.com/user-attachments/assets/0b262814-245a-4c28-8257-a269f0899347)
